### PR TITLE
Add browser language auto-redirect and language dropdown

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -371,6 +371,91 @@ body > section ul li a {
   transition: color 0.2s ease;
 }
 
+/* ── Language switcher ── */
+.lang-switcher {
+  position: relative;
+  display: inline-block;
+}
+
+.lang-switcher > summary {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 2rem;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.lang-switcher > summary::-webkit-details-marker {
+  display: none;
+}
+
+.lang-switcher > summary:hover {
+  border-color: var(--links);
+  color: var(--links);
+  text-decoration: none;
+}
+
+.lang-arrow {
+  font-size: 0.7rem;
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.lang-switcher[open] > summary .lang-arrow {
+  transform: rotate(180deg);
+}
+
+.lang-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 200;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 7.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.about-header-nav .lang-menu a {
+  display: block;
+  padding: 0.35rem 0.75rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  text-align: left;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.about-header-nav .lang-menu a:hover {
+  background: rgba(227, 188, 94, 0.08);
+  color: var(--links);
+  text-decoration: none;
+  border-color: transparent;
+}
+
+.about-header-nav .lang-menu a.active {
+  color: var(--links);
+  background: rgba(227, 188, 94, 0.12);
+  border-color: transparent;
+}
+
 /* ── Smooth scroll ── */
 html {
   scroll-behavior: smooth;

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,30 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/favicon.png" />
     <title>{% block title %} {{config.title}} {% endblock title %}</title>
+    <script>
+      (function () {
+        var p = window.location.pathname;
+        if (p !== "/" && p !== "/en/" && p !== "/jp/") return;
+        if (sessionStorage.getItem("lang-redirected")) return;
+        sessionStorage.setItem("lang-redirected", "1");
+        var saved = localStorage.getItem("preferred-lang");
+        var currentLang = document.documentElement.lang || "zh";
+        var target = saved;
+        if (!target) {
+          var bl = (navigator.language || "zh").toLowerCase();
+          target = bl.startsWith("en")
+            ? "en"
+            : bl.startsWith("ja") || bl.startsWith("jp")
+            ? "jp"
+            : "zh";
+          localStorage.setItem("preferred-lang", target);
+        }
+        if (target === currentLang) return;
+        window.location.replace(
+          target === "en" ? "/en/" : target === "jp" ? "/jp/" : "/"
+        );
+      })();
+    </script>
   </head>
   <script
     async
@@ -25,6 +49,16 @@
   </script>
   <body>
     {% block profile_header %}
+    {% if current_url %}
+      {% set _base = config.base_url %}
+      {% set _zh_url = current_url | replace(from=_base ~ "/en", to=_base) | replace(from=_base ~ "/jp", to=_base) %}
+      {% set _en_url = _zh_url | replace(from=_base ~ "/", to=_base ~ "/en/") %}
+      {% set _jp_url = _zh_url | replace(from=_base ~ "/", to=_base ~ "/jp/") %}
+    {% else %}
+      {% set _zh_url = config.base_url ~ "/" %}
+      {% set _en_url = config.base_url ~ "/en/" %}
+      {% set _jp_url = config.base_url ~ "/jp/" %}
+    {% endif %}
     <div class="about-header">
       {% if lang == "en" %} {% set about_url = config.extra.about_url_en |
       replace(from="$BASE_URL", to=config.base_url) %} {% set author =
@@ -65,6 +99,14 @@
         >{{ menu.name }}</a
       >
       {% endfor %}
+      <details class="lang-switcher">
+        <summary class="lang-current">{% if lang == "en" %}EN{% elif lang == "jp" %}JP{% else %}中{% endif %}<span class="lang-arrow">▾</span></summary>
+        <div class="lang-menu">
+          <a href="{{ _zh_url }}" class="{% if lang != 'en' and lang != 'jp' %}active{% endif %}" onclick="localStorage.setItem('preferred-lang','zh')">中文</a>
+          <a href="{{ _en_url }}" class="{% if lang == 'en' %}active{% endif %}" onclick="localStorage.setItem('preferred-lang','en')">English</a>
+          <a href="{{ _jp_url }}" class="{% if lang == 'jp' %}active{% endif %}" onclick="localStorage.setItem('preferred-lang','jp')">日本語</a>
+        </div>
+      </details>
     </nav>
     {% endblock profile_header %} {% block content %}{% endblock content %}
     <footer>
@@ -79,5 +121,11 @@
       </section>
       <section>{% block footer %}{% endblock footer %}</section>
     </footer>
+    <script>
+      document.addEventListener("click", function (e) {
+        var s = document.querySelector(".lang-switcher");
+        if (s && !s.contains(e.target)) s.removeAttribute("open");
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Auto-redirects from the homepage to the user's preferred language
  (zh/en/jp) using navigator.language on first visit; saved in localStorage
  so subsequent visits respect the choice
- Adds a language switcher dropdown (<details>/<summary>) in the nav bar
  that computes equivalent URLs for all three languages via Tera string
  replacement and updates localStorage when the user switches
- Closes the dropdown on outside click via a small inline script

https://claude.ai/code/session_01RGwFmvA7YeQCrw82LFZHeE