### PR TITLE
Add browser language auto-redirect and language dropdown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,12 +61,12 @@ menus = [
 ]
 
 menus_en = [
-    { url = "$BASE_URL/tags/", name = "Tags" },
-    { url = "$BASE_URL/metis/en", name = "Metis"}
+    { url = "$BASE_URL/en/tags/", name = "Tags" },
+    { url = "$BASE_URL/en/metis/", name = "Metis"}
 ]
 
 menus_jp = [
-    { url = "$BASE_URL/tags/", name = "Tags" },
-    { url = "$BASE_URL/metis/jp", name = "Metis"}
+    { url = "$BASE_URL/jp/tags/", name = "Tags" },
+    { url = "$BASE_URL/jp/metis/", name = "Metis"}
 ]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,10 +85,10 @@
     == "jp" %} {% set menus = config.extra.menus_jp %} {% else %} {% set menus =
     config.extra.menus %} {% endif %}
     <nav class="about-header-nav">
-      {% set base_slash = config.base_url ~ "/" %} {% set home_active =
-      current_url == base_slash %}
+      {% if lang == "en" %}{% set home_url = config.base_url ~ "/en/" %}{% elif lang == "jp" %}{% set home_url = config.base_url ~ "/jp/" %}{% else %}{% set home_url = config.base_url ~ "/" %}{% endif %}
+      {% set home_active = current_url == home_url %}
       <a
-        href="{{ config.base_url }}"
+        href="{{ home_url }}"
         class="{% if home_active %}active{% endif %}"
         >Blog</a
       >


### PR DESCRIPTION
## Summary

- Auto-redirects visitors from the homepage (`/`, `/en/`, `/jp/`) to their preferred language based on `navigator.language`; preference is saved in `localStorage` and `sessionStorage` prevents redirect loops within a session
- Adds a language switcher dropdown (`<details>/<summary>`) in the nav bar; computes equivalent URLs for all three languages (zh/en/jp) via Tera string replacement on `current_url`; clicking a language saves the choice to `localStorage`
- Fixes all nav links to preserve the current language: Tags and Metis in `menus_en`/`menus_jp` now point to `/en/tags/`, `/en/metis/`, `/jp/tags/`, `/jp/metis/` instead of the Chinese-only URLs; Blog home link is also language-aware

## Test plan

- [ ] Visit `/` with browser language set to English — should redirect to `/en/`
- [ ] Visit `/` with browser language set to Japanese — should redirect to `/jp/`
- [ ] Visit `/` with browser language set to Chinese — should stay on `/`
- [ ] After redirect, revisit `/` in same session — should NOT redirect again
- [ ] Language dropdown shows correct current language (中 / EN / JP)
- [ ] Clicking a language option navigates to the equivalent page in that language
- [ ] On English pages, clicking Blog → `/en/`, Tags → `/en/tags/`, Metis → `/en/metis/`
- [ ] On Japanese pages, clicking Blog → `/jp/`, Tags → `/jp/tags/`, Metis → `/jp/metis/`

https://claude.ai/code/session_01RGwFmvA7YeQCrw82LFZHeE