### PR TITLE
Fix Metis and About i18n pages to serve at correct language URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,8 +52,8 @@ tagline = "行動應用開發者 · Android & Flutter"
 tagline_en = "Mobile App Developer · Android & Flutter"
 tagline_jp = "モバイルアプリ開発者 · Android & Flutter"
 about_url = "$BASE_URL/about/"
-about_url_en = "$BASE_URL/about/en"
-about_url_jp = "$BASE_URL/about/jp"
+about_url_en = "$BASE_URL/en/about/"
+about_url_jp = "$BASE_URL/jp/about/"
 
 menus = [
     { url = "$BASE_URL/tags/", name = "標籤" },

--- a/content/about/about.en.md
+++ b/content/about/about.en.md
@@ -1,6 +1,5 @@
 +++
 title = "Larry Hsiao"
-path = "about/en"
 template = "about.html"
 +++
 

--- a/content/about/about.jp.md
+++ b/content/about/about.jp.md
@@ -1,6 +1,5 @@
 +++
 title = "蕭富云"
-path = "about/jp"
 template = "about.html"
 +++
 

--- a/content/metis/metis.en.md
+++ b/content/metis/metis.en.md
@@ -1,6 +1,5 @@
 +++
 title = "Metis"
-path = "metis/en"
 template = "about.html"
 description = "Put memories back on the map: journal, photos, and places woven together."
 +++

--- a/content/metis/metis.jp.md
+++ b/content/metis/metis.jp.md
@@ -1,6 +1,5 @@
 +++
 title = "Metis"
-path = "metis/jp"
 template = "about.html"
 description = "思い出を地図に戻す：日記・写真・場所をひとつに。"
 +++


### PR DESCRIPTION
## Summary

- `metis.en.md`, `metis.jp.md`, `about.en.md`, and `about.jp.md` all had custom `path` overrides (e.g. `path = "metis/en"`) that forced Zola to serve them at non-standard, default-language URLs instead of the proper i18n paths
- Removing those overrides lets Zola's multilingual system place the pages at `/en/metis/`, `/jp/metis/`, `/en/about/`, `/jp/about/` — matching the nav link URLs added in the previous PR
- Updated `about_url_en` and `about_url_jp` in `config.toml` to point to the correct `/en/about/` and `/jp/about/` URLs

## Test plan

- [ ] `/en/metis/` renders the English Metis page
- [ ] `/jp/metis/` renders the Japanese Metis page
- [ ] `/en/about/` renders the English About page
- [ ] `/jp/about/` renders the Japanese About page
- [ ] Profile header avatar/name links to the correct about page for each language
- [ ] Nav Metis links (from previous PR) resolve correctly for all three languages

https://claude.ai/code/session_01RGwFmvA7YeQCrw82LFZHeE